### PR TITLE
Add missing migration to ProductReview

### DIFF
--- a/src/oscar/apps/catalogue/reviews/migrations/0002_auto_20160527_0926.py
+++ b/src/oscar/apps/catalogue/reviews/migrations/0002_auto_20160527_0926.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('reviews', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='productreview',
+            name='email',
+            field=models.EmailField(max_length=254, verbose_name='Email', blank=True),
+        ),
+    ]


### PR DESCRIPTION
There seems to be a missing migration after the changes introduced in [Remove Django 1.7 support](https://github.com/django-oscar/django-oscar/commit/afe08db40965aee8df797d55c64a8de7fc0f3e50).
